### PR TITLE
Add Treesitter grammar support for Godot resource files and GDShader language

### DIFF
--- a/lua/godot/init.lua
+++ b/lua/godot/init.lua
@@ -7,22 +7,42 @@ local config = {
 	bin = "godot",
 	gui = {
 		console_config = {
-			relative = "editor",
 			anchor = "SW",
-			width = 99999,
-			height = 10,
-			col = 1,
-			row = 99999,
 			border = "double",
+			col = 1,
+			height = 10,
+			relative = "editor",
+			row = 99999,
 			style = "minimal",
+			width = 99999,
 		},
 	},
+	pipepath = vim.fn.stdpath("cache") .. "/godot.pipe",
 }
+
+-- Check if the pipepath is already in the server list
+-- @param pipe : path to the pipe
+local function is_server_running(pipe)
+	local servers = vim.fn.serverlist()
+	for _, server in ipairs(servers) do
+		if server == pipe then
+			return true
+		end
+	end
+	return false
+end
+
 -------------------------------------------------------------------
 -- setup
 -- @param opts : see above
 M.setup = function(opts)
 	config = vim.tbl_deep_extend("force", config, opts or {})
+
+	-- If the server is running, "serverstart" automatically sets up Neovim to listen on the given pipe
+	if not vim.loop.fs_stat(config.pipepath) and not is_server_running(config.pipepath) then
+		vim.fn.serverstart(config.pipepath)
+	end
+
 	M.debugger.setup(config)
 
 	vim.api.nvim_create_user_command("GodotDebug", M.debugger.debug, {})

--- a/lua/godot/syntax.lua
+++ b/lua/godot/syntax.lua
@@ -3,7 +3,8 @@ if not ok then
 	return
 end
 
+-- every "setup" run his own config
+-- @see https://github.com/nvim-treesitter/nvim-treesitter/blob/4d7580099155065f196a12d7fab412e9eb1526df/lua/nvim-treesitter/configs.lua#L371-L372
 ts.setup({
-    -- does this overwrite your old ensure_installed config?
-	ensure_installed = {"gdscript"}
+	ensure_installed = { "gdscript", "godot_resource", "gdshader" },
 })


### PR DESCRIPTION
- Added Treesitter grammar support for Godot resource files (`.tscn`, `.tres`, and other `.godot` files).
- Included grammar support for the `GDShader` language to improve syntax highlighting and parsing.

This update enhances the experience for Godot developers by providing better syntax support for these file types.

