### PR TITLE
Add Treesitter grammar support for Godot resource files and GDShader language

### DIFF
--- a/lua/godot/syntax.lua
+++ b/lua/godot/syntax.lua
@@ -3,7 +3,8 @@ if not ok then
 	return
 end
 
+-- every "setup" run his own config
+-- @see https://github.com/nvim-treesitter/nvim-treesitter/blob/4d7580099155065f196a12d7fab412e9eb1526df/lua/nvim-treesitter/configs.lua#L371-L372
 ts.setup({
-    -- does this overwrite your old ensure_installed config?
-	ensure_installed = {"gdscript"}
+	ensure_installed = { "gdscript", "godot_resource", "gdshader" },
 })


### PR DESCRIPTION
- Added Treesitter grammar support for `Godot resource` files (`.tscn`, `.tres`, and other `.godot` files).
- Included grammar support for the `GDShader` language to improve syntax highlighting and parsing.

This update enhances the experience for Godot developers by providing better syntax support for these file types.